### PR TITLE
Trebuchet: Avoid NPE in startAppShortcutOrInfoActivity()

### DIFF
--- a/src/com/android/launcher3/touch/ItemClickHandler.java
+++ b/src/com/android/launcher3/touch/ItemClickHandler.java
@@ -24,6 +24,7 @@ import static com.android.launcher3.Launcher.REQUEST_BIND_PENDING_APPWIDGET;
 import static com.android.launcher3.Launcher.REQUEST_RECONFIGURE_APPWIDGET;
 
 import android.app.AlertDialog;
+import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Process;
 import android.text.TextUtils;
@@ -230,7 +231,8 @@ public class ItemClickHandler {
         }
 
         TrustDatabaseHelper db = TrustDatabaseHelper.getInstance(launcher);
-        boolean isProtected = db.isPackageProtected(item.getTargetComponent().getPackageName());
+        ComponentName cn = item.getTargetComponent();
+        boolean isProtected = cn != null && db.isPackageProtected(cn.getPackageName());
 
         if (isProtected) {
             launcher.startActivitySafelyAuth(v, intent, item);


### PR DESCRIPTION
 * Fixes: https://gitlab.com/LineageOS/issues/android/issues/1450

Change-Id: I18ad506d7991e0190b89b113209389ef3217f2db